### PR TITLE
Change subject for better GMail threading

### DIFF
--- a/templates/job_failed.txt
+++ b/templates/job_failed.txt
@@ -1,4 +1,4 @@
-[GitHub] [{job_repo}]: Workflow run "{job_name}" failed!
+[GH] ({job_repo}): Workflow run "{job_name}" failed!
 -- 
 The GitHub Actions job "{job_name}" on {job_repo}.git has failed.
 Run started by GitHub user {job_actor} (triggered by {job_trigger}).

--- a/templates/job_fixed.txt
+++ b/templates/job_fixed.txt
@@ -1,4 +1,4 @@
-[GitHub] [{job_repo}]: Workflow run "{job_name}" is working again!
+[GH] ({job_repo}): Workflow run "{job_name}" is working again!
 --
 The GitHub Actions job "{job_name}" on {job_repo}.git has succeeded.
 Run started by GitHub user {job_actor} (triggered by {job_trigger}).


### PR DESCRIPTION
GMail ignores subject prefixes enclosed in [] when threading

This is the analogue of the recent changes to:

https://github.com/apache/infrastructure-github-discussions-notifier